### PR TITLE
41 mui global theme

### DIFF
--- a/src/components/options/OptionsPageApp.js
+++ b/src/components/options/OptionsPageApp.js
@@ -28,6 +28,7 @@ import WarningBox from '../shared/WarningBox'
 import Page from '../shared/Page'
 import JSZip from 'jszip'
 import { logger } from '../../helpers/logger'
+import { createTheme, ThemeProvider } from '@mui/material'
 
 /* The OptionsPageApp will be defined below */
 class App extends React.Component {
@@ -463,26 +464,34 @@ class App extends React.Component {
       return c
     })
 
+    const theme = createTheme({
+      palette: {
+        mode: this.state.isDarkMode ? 'dark' : 'light'
+      }
+    })
+
     return (
-      <Page
-        className={`main-grid${withWarning}`}
-        preferDarkMode={this.props.settings.optionalFeatures.preferDarkMode}
-        syncDarkMode={this.props.settings.optionalFeatures.syncDarkMode}
-      >
-        {this._renderWarningBox(withWarning)}
-        <div className="navigation">
-          <Navigation
-            onNavigate={(target) => this.navigateTo(target)}
-            onUpload={(upload) => this.uploadConfiguration(upload)}
-            onDelete={(configuration) => this.deleteConfiguration(configuration)}
-            items={configurations}
-            onDownloadAll={(event) => this.downloadAll(event)}
-            active={activeItem}
-            showLogs={this.props.settings.optionalFeatures.writeLogs === true}
-          />
-        </div>
-        <div className="current-view">{this.getCurrentView()}</div>
-      </Page>
+      <ThemeProvider theme={theme}>
+        <Page
+          className={`main-grid${withWarning}`}
+          preferDarkMode={this.props.settings.optionalFeatures.preferDarkMode}
+          syncDarkMode={this.props.settings.optionalFeatures.syncDarkMode}
+        >
+          {this._renderWarningBox(withWarning)}
+          <div className="navigation">
+            <Navigation
+              onNavigate={(target) => this.navigateTo(target)}
+              onUpload={(upload) => this.uploadConfiguration(upload)}
+              onDelete={(configuration) => this.deleteConfiguration(configuration)}
+              items={configurations}
+              onDownloadAll={(event) => this.downloadAll(event)}
+              active={activeItem}
+              showLogs={this.props.settings.optionalFeatures.writeLogs === true}
+            />
+          </div>
+          <div className="current-view">{this.getCurrentView()}</div>
+        </Page>
+      </ThemeProvider>
     )
   }
 }

--- a/src/components/popup/PopupPageApp.js
+++ b/src/components/popup/PopupPageApp.js
@@ -19,6 +19,7 @@ import Manifest from '../../models/Manifest'
 import { connect } from 'react-redux'
 import ConfigurationList from './ConfigurationList'
 import PropTypes from 'prop-types'
+import { createTheme, ThemeProvider } from '@mui/material'
 
 /* The PopupPageApp will be defined below */
 class App extends React.Component {
@@ -34,7 +35,8 @@ class App extends React.Component {
     super(props)
     this.state = {
       activeTab: 'apply',
-      commitHash: false
+      commitHash: false,
+      isDarkMode: window.matchMedia('(prefers-color-scheme: dark)').matches
     }
   }
 
@@ -51,51 +53,60 @@ class App extends React.Component {
     const configurations = this.props.configurations.filter(
       (config) => typeof config.deleted_at === 'undefined' && typeof config._deleted === 'undefined'
     )
+
+    const theme = createTheme({
+      palette: {
+        mode: this.state.isDarkMode ? 'dark' : 'light'
+      }
+    })
+
     return (
-      <Page
-        preferDarkMode={this.props.settings.optionalFeatures.preferDarkMode}
-        syncDarkMode={this.props.settings.optionalFeatures.syncDarkMode}
-      >
-        <Tabs activeTab={this.state.activeTab} onNavigate={(e) => this.updateActiveTab(e)}>
-          <Pane label="Apply" name="apply">
-            <ConfigurationList
-              currentUrl={this.props.currentUrl}
-              configurations={configurations}
-              settings={this.props.settings}
-              actions={this.props.actions}
+      <ThemeProvider theme={theme}>
+        <Page
+          preferDarkMode={this.props.settings.optionalFeatures.preferDarkMode}
+          syncDarkMode={this.props.settings.optionalFeatures.syncDarkMode}
+        >
+          <Tabs activeTab={this.state.activeTab} onNavigate={(e) => this.updateActiveTab(e)}>
+            <Pane label="Apply" name="apply">
+              <ConfigurationList
+                currentUrl={this.props.currentUrl}
+                configurations={configurations}
+                settings={this.props.settings}
+                actions={this.props.actions}
+              />
+            </Pane>
+            <Pane label="Help" name="help">
+              <div>
+                <b>Author:&nbsp;</b>
+                {manifest.author()}
+              </div>
+              <div>
+                <b>Homepage:&nbsp;</b>
+                {manifest.homepage()}
+              </div>
+              <div>
+                <b>Version:&nbsp;</b>
+                {manifest.version()}
+              </div>
+              <div>
+                <b>Build from </b>
+                {manifest.buildFromLink()}
+              </div>
+              <div>
+                <b>Report bugs at </b>
+                {manifest.supportLink()}
+              </div>
+            </Pane>
+            <Pane
+              link={(e) => {
+                e.preventDefault()
+                window.chrome.runtime.openOptionsPage()
+              }}
+              label="Dashboard"
             />
-          </Pane>
-          <Pane label="Help" name="help">
-            <div>
-              <b>Author:&nbsp;</b>
-              {manifest.author()}
-            </div>
-            <div>
-              <b>Homepage:&nbsp;</b>
-              {manifest.homepage()}
-            </div>
-            <div>
-              <b>Version:&nbsp;</b>
-              {manifest.version()}
-            </div>
-            <div>
-              <b>Build from </b>
-              {manifest.buildFromLink()}
-            </div>
-            <div>
-              <b>Report bugs at </b>
-              {manifest.supportLink()}
-            </div>
-          </Pane>
-          <Pane
-            link={(e) => {
-              e.preventDefault()
-              window.chrome.runtime.openOptionsPage()
-            }}
-            label="Dashboard"
-          />
-        </Tabs>
-      </Page>
+          </Tabs>
+        </Page>
+      </ThemeProvider>
     )
   }
 }


### PR DESCRIPTION
## Summary
This change will introduce the ThemeProvider on both the Options and Popup page. This allows the MUI theme to be used for any global changes and to allow transition between light and dark mode. This will not change the existing components but apply the transitional changes between light | dark on the MUI components.

The MUI components requires the Theme Configuration to apply the DarkMode on the MUI components using the media query - see reference link below. 

Reference Links:
https://mui.com/material-ui/customization/dark-mode/#system-preference

## Testing

- [x] Tested both light and dark theme changes on the Popup page
- [x] Tested both light and dark theme changes on the Options page