### PR TITLE
Bump GitHub actions to latest versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       # ESLint and Prettier must be in `package.json`
       - name: Install Node.js dependencies

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,15 +12,15 @@ jobs:
         with:
           release-type: node
           package-name: release-please-action
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         if: ${{ steps.release.outputs.releases_created }}
         with:
           node-version: '16'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.releases_created }}
       - name: 'Cache node_modules'
         if: ${{ steps.release.outputs.releases_created }}
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
     name: 'Run tests'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: '16'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: 'Cache node_modules'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             node_modules


### PR DESCRIPTION
This PR bumps GitHub actions to their latest versions, this avoiding deprectation warnings as e.g. seen [here](https://github.com/svrnm/DemoMonkey/actions/runs/7778942331).